### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,15 @@ authors = ["Michael J Coyne <mikeycgto@gmail.com>"]
 keywords = ["crypto", "security", "rails", "cookies", "sessions"]
 
 [dependencies]
+aes = "0.8.3"
+aes-gcm = "0.10.2"
 base64 = "0.21.4"
+block-padding = "0.3.3"
+cbc = { version = "0.1.2", features = ["alloc"] }
 error-chain = "0.12.4"
 hex = "0.4.3"
-rust-crypto = "0.2.36" # TODO: replace with actively maintained crate
+pbkdf2 = "0.12.2"
 rand = "0.8.5"
+sha1 = "0.10.5"
+subtle = "2.5.0"
+digest = "0.10.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "message_verifier"
 version = "1.1.0"
+edition = "2021"
 description = "Rust Message Verifier library compatible with Rails' MessageVerifier and MessageEncryptor"
 repository = "https://github.com/mikeycgto/message_verifier"
 documentation = "https://docs.rs/message_verifier"
@@ -9,7 +10,8 @@ authors = ["Michael J Coyne <mikeycgto@gmail.com>"]
 keywords = ["crypto", "security", "rails", "cookies", "sessions"]
 
 [dependencies]
-rustc-serialize = "^0.3"
-rust-crypto = "^0.2"
-rand = "0.3"
-error-chain = "0.7.1"
+base64 = "0.21.4"
+error-chain = "0.12.4"
+hex = "0.4.3"
+rust-crypto = "0.2.36" # TODO: replace with actively maintained crate
+rand = "0.8.5"

--- a/examples/aead_decrypt.rs
+++ b/examples/aead_decrypt.rs
@@ -1,7 +1,6 @@
-
 extern crate message_verifier;
 
-use message_verifier::{Encryptor, AesGcmEncryptor, DerivedKeyParams};
+use message_verifier::{AesGcmEncryptor, DerivedKeyParams, Encryptor};
 
 use std::io;
 use std::io::Read;
@@ -18,14 +17,15 @@ fn main() {
 
     match io::stdin().read_to_string(&mut message) {
         Err(_) => panic!("Read failed"),
-        Ok(_) => {
-            match encryptor.decrypt_and_verify(&message.trim()) {
-                Ok(ref decrypted_result) => {
-                    println!("Decrypted Message: {}", str::from_utf8(&decrypted_result).expect("Encryptor failed"));
-                }
-
-                Err(e) => panic!("Encryptor Error: {:?}", e)
+        Ok(_) => match encryptor.decrypt_and_verify(&message.trim()) {
+            Ok(ref decrypted_result) => {
+                println!(
+                    "Decrypted Message: {}",
+                    str::from_utf8(&decrypted_result).expect("Encryptor failed")
+                );
             }
-        }
+
+            Err(e) => panic!("Encryptor Error: {:?}", e),
+        },
     }
 }

--- a/examples/aead_encrypt.rs
+++ b/examples/aead_encrypt.rs
@@ -1,6 +1,6 @@
 extern crate message_verifier;
 
-use message_verifier::{Encryptor, AesGcmEncryptor, DerivedKeyParams};
+use message_verifier::{AesGcmEncryptor, DerivedKeyParams, Encryptor};
 
 fn main() {
     let key_base = "helloworld";
@@ -11,5 +11,10 @@ fn main() {
 
     let message = "{\"key\":\"value\"}";
 
-    println!("{}", encryptor.encrypt_and_sign(message).expect("Encryptor failed"));
+    println!(
+        "{}",
+        encryptor
+            .encrypt_and_sign(message)
+            .expect("Encryptor failed")
+    );
 }

--- a/examples/generate_encrypt.rs
+++ b/examples/generate_encrypt.rs
@@ -1,6 +1,6 @@
 extern crate message_verifier;
 
-use message_verifier::{Verifier, Encryptor, AesHmacEncryptor, DerivedKeyParams};
+use message_verifier::{AesHmacEncryptor, DerivedKeyParams, Encryptor, Verifier};
 
 fn main() {
     let key_base = "helloworld";
@@ -15,5 +15,10 @@ fn main() {
     let message = "{\"key\":\"value\"}";
 
     println!("{}", verifier.generate(message).expect("Verifier failed"));
-    println!("{}", encryptor.encrypt_and_sign(message).expect("Encryptor failed"));
+    println!(
+        "{}",
+        encryptor
+            .encrypt_and_sign(message)
+            .expect("Encryptor failed")
+    );
 }

--- a/examples/generate_encrypt.rs
+++ b/examples/generate_encrypt.rs
@@ -14,6 +14,6 @@ fn main() {
 
     let message = "{\"key\":\"value\"}";
 
-    println!("{}", verifier.generate(message));
+    println!("{}", verifier.generate(message).expect("Verifier failed"));
     println!("{}", encryptor.encrypt_and_sign(message).expect("Encryptor failed"));
 }

--- a/examples/verify_decrypt.rs
+++ b/examples/verify_decrypt.rs
@@ -1,6 +1,6 @@
 extern crate message_verifier;
 
-use message_verifier::{Verifier, Encryptor, AesHmacEncryptor, DerivedKeyParams};
+use message_verifier::{AesHmacEncryptor, DerivedKeyParams, Encryptor, Verifier};
 
 use std::io;
 use std::str;
@@ -26,28 +26,32 @@ fn main() {
                 buffer.clear();
             }
 
-            Err(_) => panic!("Read failed")
+            Err(_) => panic!("Read failed"),
         }
     }
 
     let (msg1, msg2) = match (input.first(), input.last()) {
         (Some(m1), Some(m2)) => (m1, m2),
 
-        _ => panic!("Missing input")
+        _ => panic!("Missing input"),
     };
 
     match verifier.verify(&msg1) {
-        Ok(verified_result) => {
-            match encryptor.decrypt_and_verify(&msg2) {
-                Ok(ref decrypted_result) => {
-                    println!("Verified Message: {}", str::from_utf8(&verified_result).expect("Verifier failed"));
-                    println!("Decrypted Message: {}", str::from_utf8(&decrypted_result).expect("Encryptor failed"));
-                }
-
-                Err(e) => panic!("Encryptor Error: {:?}", e)
+        Ok(verified_result) => match encryptor.decrypt_and_verify(&msg2) {
+            Ok(ref decrypted_result) => {
+                println!(
+                    "Verified Message: {}",
+                    str::from_utf8(&verified_result).expect("Verifier failed")
+                );
+                println!(
+                    "Decrypted Message: {}",
+                    str::from_utf8(&decrypted_result).expect("Encryptor failed")
+                );
             }
-        }
 
-        Err(e) => panic!("Verifier Error: {:?}", e)
+            Err(e) => panic!("Encryptor Error: {:?}", e),
+        },
+
+        Err(e) => panic!("Verifier Error: {:?}", e),
     }
 }


### PR DESCRIPTION
This PR updates all dependencies to their latest versions, and replaces the unmaintained rust-crypto crate with several smaller crates maintained by the https://github.com/RustCrypto team. To keep the changes easier to review, I held off on running `cargo fmt` until the end.

As written this does include some breaking changes:
- `set_cipher_key_size` => `self.key_size =`
- `verifier.generate` now returns an error