### PR TITLE
Update tests and docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["crypto", "security", "rails", "cookies", "sessions"]
 aes = "0.8.3"
 aes-gcm = "0.10.2"
 base64 = "0.21.4"
-block-padding = "0.3.3"
 cbc = { version = "0.1.2", features = ["alloc"] }
 error-chain = "0.12.4"
 hex = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -24,7 +24,32 @@ layer.
 
 Documentation is available on [Docs.rs](https://docs.rs/message_verifier).
 
-### Examples
+
+### A Small Example
+
+```
+ extern crate message_verifier;
+
+ use message_verifier::{Verifier, Encryptor, AesHmacEncryptor, DerivedKeyParams};
+
+ fn main() {
+     let key_base = "helloworld";
+     let salt = "test salt";
+     let sign_salt = "test signed salt";
+
+     let verifier = Verifier::new(key_base);
+
+     //let dkp = DerivedKeyParams::default();
+     //let encryptor = AesHmacEncryptor::new(key_base, salt, sign_salt, dkp).unwrap();
+
+     let message = "{\"key\":\"value\"}";
+
+     println!("{}", verifier.generate(message).expect("Verifier failed"));
+     //println!("{}", encryptor.encrypt_and_sign(message).expect("Encryptor failed"));
+ }
+```
+
+### More Examples
 
 The examples directory contains two Rust examples as well as two small
 Ruby scripts to demonstrate interoperability between this library and
@@ -32,7 +57,7 @@ ActiveSupport.
 
 One Rust example demonstrates message signing and encryption:
 
-```
+```sh
 $ cargo run --example generate_encrypt
 eyJrZXkiOiJ2YWx1ZSJ9--fa115453dbb4a28277b1ba07ef4c7437621f5d72
 MllIRUYvUFhjcXBpRk9NUWgvZ2s2UT09LS1NRmN2b2Y5SWJsaUpRNlptZFdwSlZRPT0=--2df97d947a5dc344de003715510002503fa059f1
@@ -41,7 +66,7 @@ MllIRUYvUFhjcXBpRk9NUWgvZ2s2UT09LS1NRmN2b2Y5SWJsaUpRNlptZFdwSlZRPT0=--2df97d947a
 The second reads from stdin and tries verify the first line of input and
 decrypt and verify the second:
 
-```
+```sh
 $ cargo run --example generate_encrypt | cargo run --example verify_decrypt
 Verified Message: {"key":"value"}
 Decrypted Message: {"key":"value"}
@@ -49,7 +74,7 @@ Decrypted Message: {"key":"value"}
 
 We can use these two Rust examples with the Ruby scripts as well:
 
-```
+```sh
 $ cargo run --example generate_encrypt | ruby examples/verify_decrypt.rb
 Verified message: {"key"=>"value"}
 Decrypted message: {"key"=>"value"}
@@ -72,3 +97,4 @@ If you need more cipher options, please open an issue or submit a PR!
 
 - [mjc-gh](https://github.com/mjc-gh/)
 - [seanlinsley](https://github.com/seanlinsley)
+- [endoze](https://github.com/endoze)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -470,7 +470,7 @@ mod tests {
     }
 
     #[test]
-    fn aes_hamc_decrypt_and_verify_returns_decoded_message_for_valid_messages() {
+    fn aes_hmac_decrypt_and_verify_returns_decoded_message_for_valid_messages() {
         let msg = "c20wSnp6Z1o1U2MyWDVjU3BPeWNNQT09LS1JOWNyR25LdDRpZUUvcmoxVTdoSTNRPT0=--a79c9522355e55bf8e4302c66d8bf5638f1a50ec";
 
         let dkp = DerivedKeyParams::default();
@@ -484,7 +484,7 @@ mod tests {
     }
 
     #[test]
-    fn aes_hamc_decrypt_and_verify_returns_invalid_signature_error_for_wrong_key() {
+    fn aes_hmac_decrypt_and_verify_returns_invalid_signature_error_for_wrong_key() {
         let msg = "SnRXQXFhOE9WSGg2QmVGUDdHdkhNZz09LS1vcjFWcm53VU40YmV0SVcwdWFlK2NRPT0=--c879b51cbd92559d4d684c406b3aaebfbc958e9d";
 
         let dkp = DerivedKeyParams::default();
@@ -498,7 +498,7 @@ mod tests {
     }
 
     #[test]
-    fn aes_hamc_decrypt_and_verify_returns_invalid_message_for_empty_message() {
+    fn aes_hmac_decrypt_and_verify_returns_invalid_message_for_empty_message() {
         let msg = "";
 
         let dkp = DerivedKeyParams::default();
@@ -512,7 +512,7 @@ mod tests {
     }
 
     #[test]
-    fn aes_hamc_encrypt_and_sign_returns_encrypted_and_signed_decryptable_and_verifiable_string() {
+    fn aes_hmac_encrypt_and_sign_returns_encrypted_and_signed_decryptable_and_verifiable_string() {
         let dkp = DerivedKeyParams::default();
         let encryptor =
             AesHmacEncryptor::new("helloworld", "test salt", "test signed salt", dkp).unwrap();
@@ -526,7 +526,7 @@ mod tests {
     }
 
     #[test]
-    fn aes_hamc_decrypt_and_verify_returns_decoded_message_with_non_default_cipher_for_valid_messages(
+    fn aes_hmac_decrypt_and_verify_returns_decoded_message_with_non_default_cipher_for_valid_messages(
     ) {
         let msg = "RXFQajB4VzR3QytRQ0NpQXlGUFFTdz09LS0ycUZlcWFXNlRsb1phanMvcHlwVCtRPT0=--5d4739f859e1f730dc0ae7abfb21160c9f00dae6";
 
@@ -542,7 +542,7 @@ mod tests {
     }
 
     #[test]
-    fn aes_hamc_encrypt_and_sign_returns_encrypted_and_signed_decryptable_and_verifiable_string_with_non_default_cipher(
+    fn aes_hmac_encrypt_and_sign_returns_encrypted_and_signed_decryptable_and_verifiable_string_with_non_default_cipher(
     ) {
         let dkp = DerivedKeyParams::default();
         let mut encryptor =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,34 +1,5 @@
-//! Message Verifier library compatible with Rails'
-//! [MessageVerifier](http://api.rubyonrails.org/classes/ActiveSupport/MessageVerifier.html) and
-//! [MessageEncryptor](http://api.rubyonrails.org/classes/ActiveSupport/MessageEncryptor.html).
 //!
-//! #### A Small Example
-//!
-//! Please refer to the
-//! [README](https://github.com/mikeycgto/message_verifier/blob/master/README.md)
-//! and [repo](https://github.com/mikeycgto/message_verifier) for more examples.
-//!
-//! ```
-//!  extern crate message_verifier;
-//!
-//!  use message_verifier::{Verifier, Encryptor, AesHmacEncryptor, DerivedKeyParams};
-//!
-//!  fn main() {
-//!      let key_base = "helloworld";
-//!      let salt = "test salt";
-//!      let sign_salt = "test signed salt";
-//!
-//!      let verifier = Verifier::new(key_base);
-//!
-//!      //let dkp = DerivedKeyParams::default();
-//!      //let encryptor = AesHmacEncryptor::new(key_base, salt, sign_salt, dkp).unwrap();
-//!
-//!      let message = "{\"key\":\"value\"}";
-//!
-//!      println!("{}", verifier.generate(message).expect("Verifier failed"));
-//!      //println!("{}", encryptor.encrypt_and_sign(message).expect("Encryptor failed"));
-//!  }
-//! ```
+#![doc = include_str!("../README.md")]
 
 #[macro_use]
 extern crate error_chain;


### PR DESCRIPTION
In order to simplify documentation, this PR moves most of the
documentation directly into the README.md. Additionally, to avoid
duplication, this PR pulls in the README.md into the crate docs.
This allows one source of truth for documentation and a common
experience between viewing the crate on github, crates.io, and docs.rs.

Additionally, this PR removes an unused/deprecated crate (block_modes)
and fixes minor spelling errors in the tests.